### PR TITLE
106134 endpoint login

### DIFF
--- a/controllers/oauth_controller.rb
+++ b/controllers/oauth_controller.rb
@@ -236,11 +236,12 @@ class OauthController < ApplicationController
     # we don't redirect outside the cluster.
     require 'dev_mode'
     def substitute_redirect_uri abstract_uri, desired_redirect_uri
-      if dev_mode? and URI.parse(desired_redirect_uri).host == '127.0.0.1'
-        return desired_redirect_uri
-      end
+      d = URI.parse(desired_redirect_uri)
+      return desired_redirect_uri if dev_mode? and d.host == '127.0.0.1'
       u = URI.parse abstract_uri
-      u.host = CCConfig[:external_domain]
+      # The host may be :external_domain or any of the :cluster_endpoint_aliases
+      aliases = Kato::Config.get('router2g')['cluster_endpoint_aliases']
+      u.host = aliases.include?(d.host) ? d.host : CCConfig[:external_domain]
       return u.to_s
     end
 

--- a/controllers/oauth_controller.rb
+++ b/controllers/oauth_controller.rb
@@ -91,7 +91,7 @@ class OauthController < ApplicationController
     raise Aok::Errors::NotImplemented
   end
 
-  helpers do
+  module Helpers
     def respond(status, header, response)
       if env['aok.finishable_error']
         return env['aok.finishable_error'].finish
@@ -246,5 +246,7 @@ class OauthController < ApplicationController
     end
 
   end
+
+  helpers Helpers
 
 end

--- a/spec/unit/controllers/oauth_controller_spec.rb
+++ b/spec/unit/controllers/oauth_controller_spec.rb
@@ -1,0 +1,73 @@
+require 'sinatra'
+class ApplicationController < Sinatra::Base ; end
+require_relative '../../../controllers/login_endpoint'
+require_relative '../../../controllers/oauth_controller'
+
+module Kato
+  class Config
+    def self.get ; end
+  end
+end
+
+describe OauthController::Helpers do
+  class TestHelpers
+    include OauthController::Helpers
+  end
+  let(:helpers) { TestHelpers.new }
+
+  context :substitute_redirect_uri do
+    def make_uri(host)
+      "https://#{host}/console/oauth.html"
+    end
+
+    def set_endpoint_aliases(aliases)
+      expect(Kato::Config)
+        .to receive(:get)
+        .with('router2g')
+        .and_return({'cluster_endpoint_aliases' => aliases})
+    end
+
+    CCConfig = { :external_domain => 'api.stackato.vm' }
+
+    it 'should replace ENDPOINT with the external domain' do
+      set_endpoint_aliases []
+      expect(helpers.substitute_redirect_uri make_uri('ENDPOINT'), make_uri('api.stackato.vm'))
+        .to eq(make_uri('api.stackato.vm'))
+    end
+
+    it 'should replace ENDPOINT ignoring the desired uri' do
+      set_endpoint_aliases []
+      expect(helpers.substitute_redirect_uri make_uri('ENDPOINT'), make_uri('evil.example.com'))
+        .to eq(make_uri('api.stackato.vm'))
+    end
+
+    it 'should replace ENDPOINT with desired cluster endpoint alias' do
+      set_endpoint_aliases ['different.vm']
+      expect(helpers.substitute_redirect_uri make_uri('ENDPOINT'), make_uri('different.vm'))
+        .to eq(make_uri('different.vm'))
+    end
+
+    it 'should not replace ENDPOINT with desired unknown host' do
+      set_endpoint_aliases ['different.vm']
+      expect(helpers.substitute_redirect_uri make_uri('ENDPOINT'), make_uri('evil.example.com'))
+        .to eq(make_uri('api.stackato.vm'))
+    end
+
+    it 'should support dev_mode' do
+      expect(helpers)
+        .to receive(:dev_mode?)
+        .and_return(true)
+      expect(helpers.substitute_redirect_uri make_uri('ENDPOINT'), make_uri('127.0.0.1'))
+        .to eq(make_uri('127.0.0.1'))
+    end
+
+    it 'should not support dev_mode for the wrong host' do
+      expect(helpers)
+        .to receive(:dev_mode?)
+        .and_return(true)
+      set_endpoint_aliases []
+      expect(helpers.substitute_redirect_uri make_uri('ENDPOINT'), make_uri('evil.example.com'))
+        .to eq(make_uri('api.stackato.vm'))
+    end
+  end
+end


### PR DESCRIPTION
See [bug 106134](https://bugs.activestate.com/show_bug.cgi?id=106134) for details - when `cluster_endpoint_aliases` is set, we should correctly allow them as oauth redirect targets.